### PR TITLE
Add `versions` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - List information using info
 - Mail Template Command
+- `versions` Command
 
 ## [0.0.1] - 2017-08-12
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Available Commands:
   release     Create a new release
   removed     Add a change to the list of Unreleased removals
   security    Add a change to the list of Unreleased security updates
+  versions    List all versions in a changelog
 
 Flags:
       --config string   config file (default is $HOME/.kacl.yaml)

--- a/changelog/changelog.go
+++ b/changelog/changelog.go
@@ -85,6 +85,14 @@ type Contents struct {
 	Refs       []Reference
 }
 
+func (c Contents) ChangeLogVersions() string {
+	s := ""
+	for _, element := range c.Changes {
+		s += fmt.Sprintln(element.Tag)
+	}
+	return s
+}
+
 func (c Contents) ChangeLogInfo(version string) string {
 	s := ""
 	for _, element := range c.Changes {

--- a/cmd/versions.go
+++ b/cmd/versions.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+//var Source string
+
+// versionsCmd represents the versions command
+var versionsCmd = &cobra.Command{
+	Use:     "versions",
+	//Aliases: []string{"s"},
+	Short:   "List all versions in a changelog",
+	Run: func(cmd *cobra.Command, args []string) {
+		contents, ok := getContents()
+		if !ok {
+			fmt.Println("Cannot read changelog")
+			return
+		}
+		fmt.Println(contents.ChangeLogVersions())
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionsCmd)
+}


### PR DESCRIPTION
Allow to list all the versions in a changelog (without the details of each version).